### PR TITLE
Correct #define BT_MESH_ELEM  ordering and element

### DIFF
--- a/nimble/host/mesh/include/mesh/access.h
+++ b/nimble/host/mesh/include/mesh/access.h
@@ -41,10 +41,11 @@ extern "C" {
  */
 #define BT_MESH_ELEM(_loc, _mods, _vnd_mods)        \
 {                                                   \
+        .addr             = 0                       \
 	.loc              = (_loc),                 \
 	.model_count      = ARRAY_SIZE(_mods),      \
-	.models           = (_mods),                \
 	.vnd_model_count  = ARRAY_SIZE(_vnd_mods),  \
+	.models           = (_mods),                \
 	.vnd_models       = (_vnd_mods),            \
 }
 


### PR DESCRIPTION
#define BT_MESH_ELEM expands leaving out .addr element and not in order causing errors in c++ builds.
Adding place holder for .addr and updating to correct order