### PR TITLE
Allow host to resolve peer RPA without using local RPA.

### DIFF
--- a/nimble/host/src/ble_hs_conn.c
+++ b/nimble/host/src/ble_hs_conn.c
@@ -410,22 +410,19 @@ ble_hs_conn_addrs(const struct ble_hs_conn *conn,
 
 #if MYNEWT_VAL(BLE_HOST_BASED_PRIVACY)
     /* RPA: Override peer address information. */
-    struct ble_hs_resolv_entry *rl = NULL;
-
     ble_addr_t bhc_peer_addr;
     bhc_peer_addr.type = conn->bhc_peer_addr.type;
     memcpy(bhc_peer_addr.val, conn->bhc_peer_addr.val, BLE_DEV_ADDR_LEN);
-    if (ble_host_rpa_enabled()) {
 
-        uint8_t *local_id = NULL;
-        ble_hs_id_addr(BLE_ADDR_PUBLIC, (const uint8_t **) &local_id, NULL);
+    struct ble_hs_resolv_entry *rl = NULL;
+    rl = ble_hs_resolv_list_find(bhc_peer_addr.val);
+    if (rl != NULL) {
+        memcpy(addrs->peer_id_addr.val, rl->rl_identity_addr, BLE_DEV_ADDR_LEN);
+        addrs->peer_id_addr.type = rl->rl_addr_type;
 
-        rl = ble_hs_resolv_list_find(bhc_peer_addr.val);
-        if (rl != NULL) {
-            memcpy(addrs->peer_ota_addr.val, addrs->peer_id_addr.val, BLE_DEV_ADDR_LEN);
-            memcpy(addrs->peer_id_addr.val, rl->rl_identity_addr, BLE_DEV_ADDR_LEN);
-
-            addrs->peer_id_addr.type = rl->rl_addr_type;
+        if (ble_host_rpa_enabled()) {
+            uint8_t *local_id = NULL;
+            ble_hs_id_addr(BLE_ADDR_PUBLIC, (const uint8_t **) &local_id, NULL);
 
             /* RL is present: populate our id addr with public ID */
             memcpy(addrs->our_id_addr.val, local_id, BLE_DEV_ADDR_LEN);

--- a/nimble/host/src/ble_hs_hci_evt.c
+++ b/nimble/host/src/ble_hs_hci_evt.c
@@ -332,16 +332,11 @@ ble_hs_hci_evt_le_conn_complete(uint8_t subevent, uint8_t *data, int len)
             if (ble_host_rpa_enabled()) {
                 uint8_t *local_id_rpa = ble_hs_get_rpa_local();
                 memcpy(evt.local_rpa, local_id_rpa, 6);
-
-                struct ble_hs_resolv_entry *rl = NULL;
-                ble_rpa_replace_peer_params_with_rl(evt.peer_addr,
-                                                    &evt.peer_addr_type, &rl);
-                if (rl == NULL) {
-                    if (ble_rpa_resolv_add_peer_rec(evt.peer_addr) != 0) {
-                        BLE_HS_LOG(DEBUG, "Memory unavailable for new peer record\n");
-                    }
-                }
             }
+
+            struct ble_hs_resolv_entry *rl = NULL;
+            ble_rpa_replace_peer_params_with_rl(evt.peer_addr,
+                                                &evt.peer_addr_type, &rl);
 #endif
         } else {
             memset(evt.local_rpa, 0, BLE_DEV_ADDR_LEN);

--- a/nimble/host/src/ble_hs_hci_evt.c
+++ b/nimble/host/src/ble_hs_hci_evt.c
@@ -433,14 +433,6 @@ ble_hs_hci_evt_le_adv_rpt(uint8_t subevent, uint8_t *data, int len)
         memcpy(desc.addr.val, data + off, 6);
         off += 6;
 
-#if MYNEWT_VAL(BLE_HOST_BASED_PRIVACY)
-        if (ble_host_rpa_enabled()) {
-            /* Now RPA to be resolved here, since controller is unaware of the
-             * address is RPA  */
-            ble_rpa_replace_peer_params_with_rl(desc.addr.val,
-                                                &desc.addr.type, NULL);
-        }
-#endif
         desc.length_data = data[off];
         ++off;
 

--- a/nimble/host/src/ble_sm.c
+++ b/nimble/host/src/ble_sm.c
@@ -548,26 +548,23 @@ ble_sm_persist_keys(struct ble_sm_proc *proc)
 
             identity_ev = 1;
 #if MYNEWT_VAL(BLE_HOST_BASED_PRIVACY)
-            if (ble_host_rpa_enabled())
-            {
-                struct ble_hs_dev_records *p_dev_rec =
-                                          ble_rpa_find_peer_dev_rec(conn->bhc_peer_rpa_addr.val);
-                if (p_dev_rec == NULL) {
-                    if (!ble_rpa_resolv_add_peer_rec(conn->bhc_peer_rpa_addr.val)) {
-                        p_dev_rec = ble_rpa_find_peer_dev_rec(conn->bhc_peer_rpa_addr.val);
-                    }
+            struct ble_hs_dev_records *p_dev_rec =
+                                      ble_rpa_find_peer_dev_rec(conn->bhc_peer_rpa_addr.val);
+            if (p_dev_rec == NULL) {
+                if (!ble_rpa_resolv_add_peer_rec(conn->bhc_peer_rpa_addr.val)) {
+                    p_dev_rec = ble_rpa_find_peer_dev_rec(conn->bhc_peer_rpa_addr.val);
                 }
+            }
 
-                if (p_dev_rec != NULL) {
-                    /* Once bonded, copy the peer device records */
-                    swap_buf(p_dev_rec->peer_sec.irk, proc->peer_keys.irk, 16);
-                    p_dev_rec->peer_sec.irk_present = proc->peer_keys.irk_valid;
-                    memcpy(p_dev_rec->peer_sec.peer_addr.val,
-                           proc->peer_keys.addr, 6);
-                    p_dev_rec->peer_sec.peer_addr.type = proc->peer_keys.addr_type;
+            if (p_dev_rec != NULL) {
+                /* Once bonded, copy the peer device records */
+                swap_buf(p_dev_rec->peer_sec.irk, proc->peer_keys.irk, 16);
+                p_dev_rec->peer_sec.irk_present = proc->peer_keys.irk_valid;
+                memcpy(p_dev_rec->peer_sec.peer_addr.val,
+                       proc->peer_keys.addr, 6);
+                p_dev_rec->peer_sec.peer_addr.type = proc->peer_keys.addr_type;
 
-                    ble_store_persist_peer_records();
-                }
+                ble_store_persist_peer_records();
             }
 #endif
         }


### PR DESCRIPTION
This solves an issue of not being able to resolve a bonded peer's address without the host RPA being enabled. I.E when a phone bonds with a peripheral with a static address it will not resolve and correctly identify the phone peer as bonded upon reconnection. This PR solves that issue.

https://github.com/h2zero/NimBLE-Arduino/issues/11