### PR TITLE
Prevent CCCD data from being stored when not bonded.

### DIFF
--- a/nimble/host/src/ble_gatts.c
+++ b/nimble/host/src/ble_gatts.c
@@ -1689,29 +1689,30 @@ ble_gatts_bonding_established(uint16_t conn_handle)
 
     conn = ble_hs_conn_find(conn_handle);
     BLE_HS_DBG_ASSERT(conn != NULL);
-    BLE_HS_DBG_ASSERT(conn->bhc_sec_state.bonded);
 
-    cccd_value.peer_addr = conn->bhc_peer_addr;
-    gatt_srv = &conn->bhc_gatt_svr;
+    if (conn->bhc_sec_state.bonded) {
+        cccd_value.peer_addr = conn->bhc_peer_addr;
+        gatt_srv = &conn->bhc_gatt_svr;
 
-    for (i = 0; i < gatt_srv->num_clt_cfgs; ++i) {
-        clt_cfg = (gatt_srv->clt_cfgs + i);
-        if (clt_cfg == NULL) {
-            continue;
-        }
+        for (i = 0; i < gatt_srv->num_clt_cfgs; ++i) {
+            clt_cfg = (gatt_srv->clt_cfgs + i);
+            if (clt_cfg == NULL) {
+                continue;
+            }
 
-        if (clt_cfg->flags != 0) {
-            cccd_value.chr_val_handle = clt_cfg->chr_val_handle;
-            cccd_value.flags = clt_cfg->flags;
-            cccd_value.value_changed = 0;
+            if (clt_cfg->flags != 0) {
+                cccd_value.chr_val_handle = clt_cfg->chr_val_handle;
+                cccd_value.flags = clt_cfg->flags;
+                cccd_value.value_changed = 0;
 
-            /* Store write use ble_hs_lock */
-            ble_hs_unlock();
-            ble_store_write_cccd(&cccd_value);
-            ble_hs_lock();
+                /* Store write use ble_hs_lock */
+                ble_hs_unlock();
+                ble_store_write_cccd(&cccd_value);
+                ble_hs_lock();
 
-            conn = ble_hs_conn_find(conn_handle);
-            BLE_HS_DBG_ASSERT(conn != NULL);
+                conn = ble_hs_conn_find(conn_handle);
+                BLE_HS_DBG_ASSERT(conn != NULL);
+            }
         }
     }
 

--- a/nimble/host/src/ble_sm.c
+++ b/nimble/host/src/ble_sm.c
@@ -2032,7 +2032,10 @@ ble_sm_key_exch_success(struct ble_sm_proc *proc, struct ble_sm_result *res)
     /* The procedure is now complete.  Update connection bonded state and
      * terminate procedure.
      */
-    ble_sm_update_sec_state(proc->conn_handle, 1, 0, 1, proc->key_size);
+    ble_sm_update_sec_state(proc->conn_handle, 1,
+                            !!(proc->flags & BLE_SM_PROC_F_AUTHENTICATED),
+                            !!(proc->flags & BLE_SM_PROC_F_BONDING),
+                            proc->key_size);
     proc->state = BLE_SM_PROC_STATE_NONE;
 
     res->app_status = 0;


### PR DESCRIPTION
The issue this addresses occurs when a master pairs with the device
but one of the devices does not permit bonding. In this situation,
as a slave, we will store the CCCD data anyway, but should not.
This patch corrects that.

https://github.com/apache/mynewt-nimble/issues/788