### PR TITLE
Fix gcc 13 warnings

### DIFF
--- a/nimble/host/src/ble_att_svr.c
+++ b/nimble/host/src/ble_att_svr.c
@@ -1708,6 +1708,9 @@ ble_att_svr_build_read_group_type_rsp(uint16_t conn_handle,
 
     /* Silence warnings. */
     end_group_handle = 0;
+    start_group_handle = 0;
+
+    entry = NULL;
 
     *att_err = 0;
     *err_handle = start_handle;
@@ -1728,7 +1731,6 @@ ble_att_svr_build_read_group_type_rsp(uint16_t conn_handle,
         goto done;
     }
 
-    start_group_handle = 0;
     rsp->bagp_length = 0;
     STAILQ_FOREACH(entry, &ble_att_svr_list, ha_next) {
         if (entry->ha_handle_id < start_handle) {


### PR DESCRIPTION
This change fixes warnings that appeared when compiling with GCC 13.1.0:

```
/home/alex/git/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_att_svr.c:1838:16: error: 'entry' may be used uninitialized [-Werror=maybe-uninitialized]
 1838 |             if (entry == NULL) {
      |                ^
/home/alex/git/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_att_svr.c:1713:31: note: 'entry' was declared here
 1713 |     struct ble_att_svr_entry *entry;
      |                               ^~~~~
/home/alex/git/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_att_svr.c:1846:18: error: 'start_group_handle' may be used uninitialized [-Werror=maybe-uninitialized]
 1846 |             rc = ble_att_svr_read_group_type_entry_write(txom, mtu,
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1847 |                                                          start_group_handle,
      |                                                          ~~~~~~~~~~~~~~~~~~~
 1848 |                                                          end_group_handle,
      |                                                          ~~~~~~~~~~~~~~~~~
 1849 |                                                          &service_uuid.u);
      |                                                          ~~~~~~~~~~~~~~~~
/home/alex/git/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_att_svr.c:1715:14: note: 'start_group_handle' was declared here
 1715 |     uint16_t start_group_handle;
      |              ^~~~~~~~~~~~~~~~~~
cc1: some warnings being treated as errors
```