### PR TITLE
fix compilation because of unknown MYNEWT_VAL

### DIFF
--- a/nimble/host/services/gap/include/services/gap/ble_svc_gap.h
+++ b/nimble/host/services/gap/include/services/gap/ble_svc_gap.h
@@ -20,6 +20,7 @@
 #ifndef H_BLE_SVC_GAP_
 #define H_BLE_SVC_GAP_
 
+#include "syscfg/syscfg.h"
 #include <inttypes.h>
 #if MYNEWT_VAL(ENC_ADV_DATA)
 #include "host/ble_ead.h"


### PR DESCRIPTION
MYNEWT_VAL is unknown in the scope of this file in some or at least my build environment.

Getting this error message:
```
.../esp32/include/bt/host/nimble/nimble/nimble/host/services/gap/include/services/gap/ble_svc_gap.h:25:15: error: missing binary operator before token "("
   25 | #if MYNEWT_VAL(ENC_ADV_DATA)
```

Adding this include fixes this for me.