### PR TITLE
Small fix to ble_gap_unpair_oldest_peer to avoid writing to invalid memory

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -6539,7 +6539,7 @@ int
 ble_gap_unpair_oldest_peer(void)
 {
 #if NIMBLE_BLE_SM
-    ble_addr_t oldest_peer_id_addr;
+    ble_addr_t oldest_peer_id_addr[MYNEWT_VAL(BLE_STORE_MAX_BONDS)];
     int num_peers;
     int rc;
 
@@ -6548,7 +6548,7 @@ ble_gap_unpair_oldest_peer(void)
     }
 
     rc = ble_store_util_bonded_peers(
-            &oldest_peer_id_addr, &num_peers, MYNEWT_VAL(BLE_STORE_MAX_BONDS));
+            &oldest_peer_id_addr[0], &num_peers, MYNEWT_VAL(BLE_STORE_MAX_BONDS));
     if (rc != 0) {
         return rc;
     }
@@ -6557,7 +6557,7 @@ ble_gap_unpair_oldest_peer(void)
         return BLE_HS_ENOENT;
     }
 
-    rc = ble_gap_unpair(&oldest_peer_id_addr);
+    rc = ble_gap_unpair(&oldest_peer_id_addr[0]);
     if (rc != 0) {
         return rc;
     }


### PR DESCRIPTION
There was a recent change to `ble_gap_unpair_oldest_peer` that fixed how `ble_store_util_bonded_pairs` was called. However that fix did not increase the size of the buffer, so the call to `ble_store_util_bonded_pairs` would result in writing past the buffer passed in. This small change fixes that behavior.