### PR TITLE
Fixed warnings

### DIFF
--- a/nimble/host/src/ble_hs_hci.c
+++ b/nimble/host/src/ble_hs_hci.c
@@ -106,7 +106,7 @@
 
 struct err_code {
     int error_code;
-    char *msg;
+    const char *msg;
 };
 
 static struct err_code err_code_list[] = {


### PR DESCRIPTION
If building an IDF app with
CONFIG_COMPILER_WARN_WRITE_STRINGS=y, the
compiler emits warnings about the non-const
pointer pointing to literal strings. This fixes
it.
