### PR TITLE
ble_gattc: Fix proc rx entry comparison

### DIFF
--- a/nimble/host/src/ble_gattc.c
+++ b/nimble/host/src/ble_gattc.c
@@ -989,8 +989,8 @@ ble_gattc_proc_matches_conn_rx_entry(struct ble_gattc_proc *proc, void *arg)
     criteria = arg;
 
     if (criteria->conn_handle != BLE_HS_CONN_HANDLE_NONE &&
-        criteria->conn_handle != proc->conn_handle &&
-        criteria->cid != proc->cid) {
+        (criteria->conn_handle != proc->conn_handle ||
+         criteria->cid != proc->cid)) {
 
         return 0;
     }


### PR DESCRIPTION
Incorrect comparison causes request/response mismatches when multiple ops are in flight

Bug introduced in https://github.com/espressif/esp-nimble/commit/a690a0596597294fd85bee397e9df9ca81b0b48d