### PR TITLE
fix(nimble): Dynamic services fixes

### DIFF
--- a/nimble/host/src/ble_gatts.c
+++ b/nimble/host/src/ble_gatts.c
@@ -1786,6 +1786,7 @@ int
 ble_gatts_conn_can_alloc(void)
 {
     return ble_gatts_num_cfgable_chrs == 0 ||
+           ble_gatts_clt_cfg_pool.mp_num_blocks == 0 ||
            ble_gatts_clt_cfg_pool.mp_num_free > 0;
 }
 

--- a/nimble/host/src/ble_gatts.c
+++ b/nimble/host/src/ble_gatts.c
@@ -2868,7 +2868,7 @@ int ble_gatts_add_dynamic_svcs(const struct ble_gatt_svc_def *svcs) {
     ble_gatts_free_svc_defs();
      /* Fill the cache. */
     cfg = ble_gatts_get_last_cfg(&ble_gatts_clt_cfgs);
-    ha = ble_att_svr_find_by_handle(cfg->chr_val_handle - 1);
+    ha = cfg == NULL ? NULL : ble_att_svr_find_by_handle(cfg->chr_val_handle - 1);
     while ((ha = ble_att_svr_find_by_uuid(ha, &uuid.u, 0xffff)) != NULL) {
         chr = ha->ha_cb_arg;
         allowed_flags = ble_gatts_chr_clt_cfg_allowed(chr);


### PR DESCRIPTION
## Description

I have identified two issues that occur when using _only_ dynamic services:

1. `ble_gatts_get_last_cfg` is used which may initially return `NULL` if there are no static services - this needs to be checked.
2. `ble_gatts_conn_can_alloc` may wrongly return `false` because there are no free blocks in the `ble_gatts_clt_cfg_pool`, which is empty due to there being no static services.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
