### PR TITLE
fix(nimble): Fix compile errors when CSFCS or BONDS are 0

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -8302,7 +8302,7 @@ ble_gap_unpair(const ble_addr_t *peer_addr)
 int
 ble_gap_unpair_oldest_peer(void)
 {
-#if NIMBLE_BLE_SM
+#if NIMBLE_BLE_SM && MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     ble_addr_t oldest_peer_id_addr[MYNEWT_VAL(BLE_STORE_MAX_BONDS)];
     int num_peers;
     int rc;
@@ -9286,8 +9286,10 @@ ble_gap_host_check_status(void)
     uint16_t sync_handle = 0;
 #endif
     struct ble_hs_conn *conn;
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     ble_addr_t oldest_peer_id_addr[MYNEWT_VAL(BLE_STORE_MAX_BONDS)];
     int num_peers = 0;
+#endif
 
     /* Stop Advertising */
 #if MYNEWT_VAL(BLE_EXT_ADV)
@@ -9328,6 +9330,7 @@ ble_gap_host_check_status(void)
 	}
     }
 
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     /* Check for paired devices*/
     ble_store_util_bonded_peers(&oldest_peer_id_addr[0],
 		    &num_peers, MYNEWT_VAL(BLE_STORE_MAX_BONDS));
@@ -9336,6 +9339,7 @@ ble_gap_host_check_status(void)
         BLE_HS_LOG(ERROR, "Unpaired device exists\n");
 	status |= BIT(BLE_GAP_STATUS_PAIRED);
     }
+#endif
 
     /* gatts reset */
     if (ble_gatts_get_cfgable_chrs()) {

--- a/nimble/host/store/config/src/ble_store_config.c
+++ b/nimble/host/store/config/src/ble_store_config.c
@@ -699,6 +699,7 @@ ble_store_config_write_ead(const struct ble_store_value_ead *value_ead)
 static int
 ble_store_config_find_local_irk(const struct ble_store_key_local_irk *key)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     struct ble_store_value_local_irk *local_irk;
     int skipped;
     int i;
@@ -720,7 +721,7 @@ ble_store_config_find_local_irk(const struct ble_store_key_local_irk *key)
 
         return i;
     }
-
+#endif
     return -1;
 }
 
@@ -769,6 +770,7 @@ ble_store_config_read_local_irk(const struct ble_store_key_local_irk *key_irk,
 static int
 ble_store_config_write_local_irk(const struct ble_store_value_local_irk *value_irk)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     struct ble_store_key_local_irk key_irk;
     int idx;
     int rc;
@@ -795,6 +797,9 @@ ble_store_config_write_local_irk(const struct ble_store_value_local_irk *value_i
     }
 
     return 0;
+#else
+    return BLE_HS_ENOTSUP;
+#endif
 }
 
 
@@ -910,6 +915,7 @@ ble_store_config_delete_rpa_rec(const struct ble_store_key_rpa_rec *key_rpa_rec)
  * $csfc                                                                     *
  *****************************************************************************/
 
+#if MYNEWT_VAL(BLE_STORE_MAX_CSFCS)
 static int
 ble_store_config_find_csfc(const struct ble_store_key_csfc *key,
                            const struct ble_store_value_csfc *value_csfc,
@@ -934,10 +940,12 @@ ble_store_config_find_csfc(const struct ble_store_key_csfc *key,
 
     return -1;
 }
+#endif
 
 static int
 ble_store_config_delete_csfc(const struct ble_store_key_csfc *key_csfc)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_CSFCS)
     int idx;
     int rc;
 
@@ -961,12 +969,16 @@ ble_store_config_delete_csfc(const struct ble_store_key_csfc *key_csfc)
     }
 
     return 0;
+#else
+    return BLE_HS_ENOENT;
+#endif
 }
 
 static int
 ble_store_config_read_csfc(const struct ble_store_key_csfc *key_csfc,
                            struct ble_store_value_csfc *value_csfc)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_CSFCS)
     int idx;
 
     idx = ble_store_config_find_csfc(key_csfc, ble_store_config_csfcs,
@@ -977,11 +989,15 @@ ble_store_config_read_csfc(const struct ble_store_key_csfc *key_csfc,
 
     *value_csfc = ble_store_config_csfcs[idx];
     return 0;
+#else
+    return BLE_HS_ENOENT;
+#endif
 }
 
 static int
 ble_store_config_write_csfc(const struct ble_store_value_csfc *value_csfc)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_CSFCS)
     struct ble_store_key_csfc key_csfc;
     int idx;
     int rc;
@@ -1008,6 +1024,9 @@ ble_store_config_write_csfc(const struct ble_store_value_csfc *value_csfc)
     }
 
     return 0;
+#else
+    return BLE_HS_ENOENT;
+#endif
 }
 
 /*****************************************************************************


### PR DESCRIPTION
## Description

Fixes GCC compile errors such as:

```
C:/Espressif/frameworks/esp-idf-v5.4/components/bt/host/nimble/nimble/nimble/host/src/ble_gap.c:8314:10: error: array subscript 0 is outside array bounds of 'ble_addr_t[0]' [-Werror=array-bounds=]
 8314 |     rc = ble_store_util_bonded_peers(
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
 8315 |             &oldest_peer_id_addr[0], &num_peers, MYNEWT_VAL(BLE_STORE_MAX_BONDS));
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
