### PR TITLE
fix(nimble): Fix undefined reference in ble_hs_deinit when GATT Server is disabled

### DIFF
--- a/nimble/host/src/ble_hs.c
+++ b/nimble/host/src/ble_hs.c
@@ -934,8 +934,9 @@ ble_hs_deinit(void)
 
 #if NIMBLE_BLE_CONNECT
     ble_npl_event_deinit(&ble_hs_ev_tx_notifications);
-
+#if MYNEWT_VAL(BLE_GATTS)
     ble_gatts_stop();
+#endif
 #endif
 
     ble_npl_callout_deinit(&ble_hs_timer);


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
Since commit https://github.com/espressif/esp-nimble/commit/45352c459af99759de65076a8327a1c865bb2a4e compilation of the https://github.com/espressif/esp-idf/tree/master/examples/bluetooth/nimble/blecent example with

```
CONFIG_BT_NIMBLE_GATT_SERVER=n  #Will also be disabled when CONFIG_BT_NIMBLE_ROLE_PERIPHERAL=n
CONFIG_EXAMPLE_INIT_DEINIT_LOOP=y
```

will fail with
```
/home/root/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/bin/../lib/gcc/xtensa-esp-elf/14.2.0/../../../../xtensa-esp-elf/bin/ld: esp-idf/bt/libbt.a(ble_hs.c.obj):(.literal.ble_hs_deinit+0x4): undefined reference to `ble_gatts_stop'
/home/root/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/bin/../lib/gcc/xtensa-esp-elf/14.2.0/../../../../xtensa-esp-elf/bin/ld: esp-idf/bt/libbt.a(ble_hs.c.obj): in function `ble_hs_deinit':
/home/root/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_hs.c:933:(.text.ble_hs_deinit+0x4b): undefined reference to `ble_gatts_stop'
```
<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related
- Commit https://github.com/espressif/esp-nimble/commit/45352c459af99759de65076a8327a1c865bb2a4e
<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing
Example builds succesfully with this change
<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
