### PR TITLE
ble_sm_alg: Replace use of CTR DRBG with mbedtls_esp_random

### DIFF
--- a/nimble/host/src/ble_sm_alg.c
+++ b/nimble/host/src/ble_sm_alg.c
@@ -35,10 +35,10 @@
 #include "mbedtls/aes.h"
 #include "mbedtls/cipher.h"
 #include "mbedtls/entropy.h"
-#include "mbedtls/ctr_drbg.h"
 #include "mbedtls/cmac.h"
 #include "mbedtls/ecdh.h"
 #include "mbedtls/ecp.h"
+#include "mbedtls/esp_mbedtls_random.h"
 #endif // CONFIG_MBEDTLS_VER_4_X_SUPPORT
 #else
 #include "tinycrypt/aes.h"
@@ -658,8 +658,6 @@ exit:
 
     struct mbedtls_ecp_point pt = {0}, Q = {0};
     mbedtls_mpi z = {0}, d = {0};
-    mbedtls_ctr_drbg_context ctr_drbg = {0};
-    mbedtls_entropy_context entropy = {0};
 
     uint8_t pub[65] = {0};
     /* Hardcoded first byte of pub key for MBEDTLS_ECP_PF_UNCOMPRESSED */
@@ -669,8 +667,6 @@ exit:
     /* Initialize the required structures here */
     mbedtls_ecp_point_init(&pt);
     mbedtls_ecp_point_init(&Q);
-    mbedtls_ctr_drbg_init(&ctr_drbg);
-    mbedtls_entropy_init(&entropy);
     mbedtls_mpi_init(&d);
     mbedtls_mpi_init(&z);
 
@@ -687,12 +683,6 @@ exit:
         goto exit;
     }
 
-    /* Set PRNG */
-    if ( ( rc = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
-                                      NULL, 0) ) != 0) {
-        goto exit;
-    }
-
     /* Prepare point Q from pub key */
     if (mbedtls_ecp_point_read_binary(&keypair.MBEDTLS_PRIVATE(grp), &Q, pub, 65) != 0) {
         goto exit;
@@ -703,7 +693,7 @@ exit:
     }
 
     rc = mbedtls_ecdh_compute_shared(&keypair.MBEDTLS_PRIVATE(grp), &z, &Q, &d,
-                                     mbedtls_ctr_drbg_random, &ctr_drbg);
+                                     mbedtls_esp_random, NULL);
     if (rc != 0) {
         goto exit;
     }
@@ -718,8 +708,6 @@ exit:
     mbedtls_mpi_free(&z);
     mbedtls_mpi_free(&d);
     mbedtls_ecp_point_free(&Q);
-    mbedtls_entropy_free(&entropy);
-    mbedtls_ctr_drbg_free(&ctr_drbg);
 #endif // CONFIG_MBEDTLS_VER_4_X_SUPPORT
     if (rc != 0) {
 #if MYNEWT_VAL(BLE_SM_SC) && MYNEWT_VAL(BLE_STATIC_TO_DYNAMIC)
@@ -816,8 +804,6 @@ exit:
         return BLE_HS_EUNKNOWN;
     }
 #else
-    mbedtls_entropy_context entropy = {0};
-    mbedtls_ctr_drbg_context ctr_drbg = {0};
 
 #if MYNEWT_VAL(BLE_SM_SC) && MYNEWT_VAL(BLE_STATIC_TO_DYNAMIC)
     if (!keypair_ptr) {
@@ -825,21 +811,13 @@ exit:
     }
 #endif
 
-    mbedtls_entropy_init(&entropy);
-    mbedtls_ctr_drbg_init(&ctr_drbg);
-
     /* Free the previously allocate keypair */
     mbedtls_ecp_keypair_free(&keypair);
 
     mbedtls_ecp_keypair_init(&keypair);
 
-    if (( rc = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
-                                NULL, 0)) != 0) {
-        goto exit;
-    }
-
     if ((rc = mbedtls_ecp_gen_key(MBEDTLS_ECP_DP_SECP256R1, &keypair,
-                                  mbedtls_ctr_drbg_random, &ctr_drbg)) != 0) {
+                                  mbedtls_esp_random, NULL)) != 0) {
         goto exit;
     }
 
@@ -858,8 +836,6 @@ exit:
     memcpy(public_key, &pub[1], 64);
 
 exit:
-    mbedtls_ctr_drbg_free( &ctr_drbg );
-    mbedtls_entropy_free( &entropy );
     if (rc != 0) {
         mbedtls_ecp_keypair_free(&keypair);
 


### PR DESCRIPTION
## Description

ESP has a HW TRNG that produces good quality random numbers without the need to pass them through a PRNG such as CTR DRBG.

[mbedtls_esp_random](https://github.com/espressif/esp-idf/blob/master/components/mbedtls/port/include/mbedtls/esp_mbedtls_random.h#L28) is the RNG function providing access to ESP's HW TRNG.

Dropping usage of CTR DRBG by nimble eliminates it from the firnmware, saving a few K of space.

## Related

This PR is similar to [the change](https://github.com/espressif/esp-idf/commit/f933e51ad9fb752f7aca6d42e556f70f538eadf0) previously made to wpa_sucpplicant.

## Testing

Been using this patch for a while internally.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
