### PR TITLE
GATT fixes (server-only, dynamic-services-only, no-bonds)

### DIFF
--- a/nimble/host/src/ble_gattc_cache_conn.c
+++ b/nimble/host/src/ble_gattc_cache_conn.c
@@ -2052,7 +2052,6 @@ ble_gattc_cache_conn_update(uint16_t conn_handle, uint16_t start_handle, uint16_
         peer->cache_state = CACHE_INVALID;
     }
 }
-#endif
 
 int ble_gattc_cache_refresh(ble_addr_t peer_addr)
 {
@@ -2088,6 +2087,7 @@ int ble_gattc_cache_refresh(ble_addr_t peer_addr)
 
     return rc;
 }
+#endif
 
 #if MYNEWT_VAL(BLE_GATT_CACHING_ASSOC_ENABLE)
 static int

--- a/nimble/host/src/ble_gatts.c
+++ b/nimble/host/src/ble_gatts.c
@@ -2025,6 +2025,7 @@ ble_gatts_conn_can_alloc(void)
 #endif
 
     return ble_gatts_num_cfgable_chrs == 0 ||
+           ble_gatts_clt_cfg_pool.mp_num_blocks == 0 ||
            ble_gatts_clt_cfg_pool.mp_num_free > 0;
 }
 

--- a/nimble/host/src/ble_gatts.c
+++ b/nimble/host/src/ble_gatts.c
@@ -1862,6 +1862,7 @@ ble_gatts_start(void)
 
 #if MYNEWT_VAL(BLE_GATT_CACHING)
 #if MYNEWT_VAL(BLE_STATIC_TO_DYNAMIC)
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     if (ble_gatts_conn_aware_states == NULL) {
         ble_gatts_conn_aware_states = nimble_platform_mem_calloc(1, sizeof(struct ble_gatts_aware_state) * MYNEWT_VAL(BLE_STORE_MAX_BONDS));
         if (ble_gatts_conn_aware_states == NULL) {
@@ -1869,6 +1870,7 @@ ble_gatts_start(void)
             goto done;
         }
     }
+#endif
 #else
     memset(ble_gatts_conn_aware_states, 0, sizeof ble_gatts_conn_aware_states);
 #endif


### PR DESCRIPTION
## Summary

Three small fixes for build/runtime issues that appear when NimBLE is built with non-default configurations (server-only, dynamic-services-only, no bonds).

  ### Commits

  - **`a656f28` fix(nimble): Allow connections when only using dynamic services**
    When only dynamic services are registered, the static `ble_gatts_clt_cfg_pool` is initialized with zero blocks, so `mp_num_free == 0` permanently — `ble_gatts_conn_can_alloc()` then refuses every connection. Treat `mp_num_blocks == 0` as "pool unused" rather than "pool exhausted".

  - **`0307d1b` fix(nimble): Guard ble_gattc_cache_refresh with BLE_GATTC**
    `ble_gattc_cache_refresh()` calls client-only APIs but sat outside the surrounding `#if MYNEWT_VAL(BLE_GATTC)` guard, breaking server-only builds. Moves the `#endif` past the function.

  - **`30f3498` fix(nimble): Only allocate ble_gatts_conn_aware_states if MAX_BONDS > 0**
    In `ble_gatts_start()`, the `nimble_platform_mem_calloc(1, sizeof(...) * BLE_STORE_MAX_BONDS)` call zero-sizes when `BLE_STORE_MAX_BONDS == 0`, and the subsequent NULL check then fails the start. Skip the allocation entirely when no bonds are configured.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
