### PR TITLE
nimble/host: guard ble_gattc_cache_refresh() with BLE_GATTC

### DIFF
--- a/nimble/host/src/ble_gattc_cache_conn.c
+++ b/nimble/host/src/ble_gattc_cache_conn.c
@@ -2071,6 +2071,7 @@ ble_gattc_cache_conn_update(uint16_t conn_handle, uint16_t start_handle, uint16_
 
 int ble_gattc_cache_refresh(ble_addr_t peer_addr)
 {
+#if MYNEWT_VAL(BLE_GATTC)
     struct ble_hs_conn *hs_conn;
     struct ble_gattc_cache_conn *conn;
     int rc;
@@ -2104,6 +2105,14 @@ int ble_gattc_cache_refresh(ble_addr_t peer_addr)
     rc = ble_gattc_cache_conn_disc(conn);
 
     return rc;
+#else
+    /* Refreshing a peer's GATT cache requires the GATT client. On a
+     * server-only build (BLE_GATT_CACHING enabled without BLE_GATTC) there is
+     * nothing to refresh, so report the operation as unsupported instead of
+     * referencing client-only helpers that are compiled out. */
+    (void)peer_addr;
+    return BLE_HS_ENOTSUP;
+#endif
 }
 
 #if MYNEWT_VAL(BLE_GATT_CACHING_ASSOC_ENABLE)


### PR DESCRIPTION
## Summary

`ble_gattc_cache_refresh()` is compiled whenever `BLE_GATT_CACHING` is enabled,
but its body calls `ble_gattc_cache_conn_find_by_addr()`,
`ble_gattc_cacheReset()` and `ble_gattc_cache_conn_disc()` — all defined only
inside `#if MYNEWT_VAL(BLE_GATTC)` blocks. On a server-only build
(`BLE_GATT_CACHING && !BLE_GATTC`) it fails to compile:

```
ble_gattc_cache_conn.c: In function 'ble_gattc_cache_refresh':
error: implicit declaration of function 'ble_gattc_cache_conn_disc';
       did you mean 'ble_gattc_cache_conn_find'?
```

This combination is reached on peripheral/GATT-server-only products that enable
GATT caching for the Database Hash / Service Changed feature — e.g. ESP-IDF's
`ble_conn_mgr` `BLE_CONN_MGR_GATT_CHANGED_AUTO`, which `select`s
`BT_NIMBLE_GATT_CACHING` while `BT_NIMBLE_GATT_CLIENT` (→ `BLE_GATTC`) stays off
because it depends on the central role.

## Fix

Guard the body of `ble_gattc_cache_refresh()` with `#if MYNEWT_VAL(BLE_GATTC)`
and return `BLE_HS_ENOTSUP` when the GATT client is absent — there is no peer
cache to refresh without it. The public symbol remains available so server-only
builds with caching link cleanly.

Minimal, no behavior change when `BLE_GATTC` is enabled.

Fixes espressif/esp-nimble#127